### PR TITLE
Add a test to ensure that all columns are documented

### DIFF
--- a/spec/automated_review/column_documentation_spec.rb
+++ b/spec/automated_review/column_documentation_spec.rb
@@ -1,0 +1,14 @@
+describe "Column documentation" do
+  #Documented tables
+  ["conversion_hosts"].each do |table_name|
+    it "#{table_name} columns are documented" do
+      klass = Class.new(ActiveRecord::Base) do
+        self.table_name = table_name
+      end
+
+      klass.columns.each do |column|
+        expect(column.comment).not_to be_nil, "#{table_name}##{column.name} is not documented."
+      end
+    end
+  end
+end


### PR DESCRIPTION
Based on: https://github.com/ManageIQ/manageiq-schema/pull/335#pullrequestreview-203434891

Before the migration:
```
$ rspec spec/automated_review/column_documentation_spec.rb
F

Failures:

  1) Column documentation conversion_hosts columns are documented
     Failure/Error: expect(column.comment).not_to be_nil, "#{table_name}##{column.name} is not documented."
       conversion_hosts#id is not documented.
     # ./spec/automated_review/column_documentation_spec.rb:10:in `block (4 levels) in <top (required)>'
     # ./spec/automated_review/column_documentation_spec.rb:9:in `each'
     # ./spec/automated_review/column_documentation_spec.rb:9:in `block (3 levels) in <top (required)>'

Finished in 0.03025 seconds (files took 1.31 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/automated_review/column_documentation_spec.rb:4 # Column documentation conversion_hosts columns are documented
```

After the migration:
```
$ rspec spec/automated_review/column_documentation_spec.rb
.

Finished in 0.0202 seconds (files took 1.25 seconds to load)
1 example, 0 failures
```